### PR TITLE
feat: convert value from float64 to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It produces the following messages in a kafka topic:
 ```json
 {
   "__timestamp__": 1234567890,
-  "__value__": 9876543210,
+  "__value__": "9876543210",
   
   "__name__": "up",
   "job": "federation",

--- a/prometheus.go
+++ b/prometheus.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"encoding/json"
+	"strconv"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
@@ -35,7 +36,7 @@ func processWriteRequest(req *prompb.WriteRequest) ([][]byte, error) {
 
 		for _, sample := range ts.Samples {
 			metric := make(map[string]interface{}, len(labels)+2)
-			metric["__value__"] = sample.Value
+			metric["__value__"] = strconv.FormatFloat(sample.Value, 'f', -1, 64)
 			metric["__timestamp__"] = sample.Timestamp
 
 			for key, value := range labels {


### PR DESCRIPTION
This PR changes the type of "`__value__`" from `float64` to `string` to handle `NaN`, `+Inf` and `-Inf`. Suggested by https://github.com/prometheus/docs/pull/1197#issuecomment-431059439. Close #12.