### PR TITLE
Bump Kafka dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.13.6-alpine3.10 as build
 
-RUN apk add --no-cache alpine-sdk librdkafka librdkafka-dev
+RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+RUN echo "@edgecommunity http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories  
+RUN apk add --no-cache alpine-sdk 'librdkafka@edgecommunity>=1.3.0' 'librdkafka-dev@edgecommunity>=1.3.0'
 
 WORKDIR /src/prometheus-kafka-adapter
 ADD . /src/prometheus-kafka-adapter

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/Telefonica/prometheus-kafka-adapter
 require (
 	github.com/actgardner/gogen-avro v5.1.0+incompatible // indirect
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
-	github.com/confluentinc/confluent-kafka-go v1.0.0
+	github.com/confluentinc/confluent-kafka-go v1.3.0
 	github.com/containous/traefik v1.7.1
-	github.com/edenhill/librdkafka v1.0.1
+	github.com/edenhill/librdkafka v1.3.0
 	github.com/fatih/structs v1.1.0
 	github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7 // indirect
 	github.com/gin-gonic/contrib v0.0.0-20180614032058-39cfb9727134

--- a/go.sum
+++ b/go.sum
@@ -5,11 +5,15 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/confluentinc/confluent-kafka-go v1.0.0 h1:y+G9NTXsvoelf1cRzjtLKOZsPqh71noS4+t+e+eINIk=
 github.com/confluentinc/confluent-kafka-go v1.0.0/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
+github.com/confluentinc/confluent-kafka-go v1.3.0 h1:1gJm/SgUqG01jRYJ1pSZ9GldAhXZ0xrFPKxINlVZ3z0=
+github.com/confluentinc/confluent-kafka-go v1.3.0/go.mod h1:MPUvNqmycSJrQZKGPS6LyLZLJH1hmLKkBmHQgQR7Ma0=
 github.com/containous/traefik v1.7.1 h1:8fZ0MIRANiu39sBo/sIVy1EV1hRKcdz1Nc1QQjpL5zM=
 github.com/containous/traefik v1.7.1/go.mod h1:epDRqge3JzKOhlSWzOpNYEEKXmM6yfN5tPzDGKk3ljo=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/edenhill/librdkafka v1.0.1/go.mod h1:F8PuMcF+v4otvUmH+SaJzju25e4o1IZunsVnaYzfIYo=
+github.com/edenhill/librdkafka v1.3.0 h1:/mXXSTLIFLRCGaVKFbVbx2BDC0FdGtyqrI0NxbWcIfI=
+github.com/edenhill/librdkafka v1.3.0/go.mod h1:F8PuMcF+v4otvUmH+SaJzju25e4o1IZunsVnaYzfIYo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7 h1:AzN37oI0cOS+cougNAV9szl6CVoj2RYwzS3DpUQNtlY=
 github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=


### PR DESCRIPTION
Bump librdkafka from v1.0.1 to v.1.30
Bump confluent-kafka-go v1.0.0 to v1.3.0
Bump librdkafka and librdkafka-dev version to >1.3.0
At the moment librdkafka>=1.3.0 is only available from
the community/edge repository.

Fixes #34 