### PR TITLE
Fix librdkafka in final Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,16 @@ language: minimal
 
 services:
   - docker
+jobs:
+  include:
+    - stage: install
+      script: docker build -t telefonica/prometheus-kafka-adapter .
 
-install:
-  - docker build -t telefonica/prometheus-kafka-adapter .
-
-test:
-  - docker build -t telefonica/prometheus-kafka-adapter .
-  - docker run -d --name test telefonica/prometheus-kafka-adapter
-  - if [ $(docker inspect -f {{.State.Status}} test) = "running" ]; then echo "OK"; exit 0; else echo
-    "FAILED"; exit 1; fi
+    - stage: test
+      script:
+        - docker build -t telefonica/prometheus-kafka-adapter .
+        - docker run -d --name test telefonica/prometheus-kafka-adapter
+        - if [ $(docker inspect -f {{.State.Status}} test) = "running" ]; then echo "OK"; exit 0; else echo "FAILED"; exit 1; fi
 
 git:
   depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ services:
 install:
   - docker build -t telefonica/prometheus-kafka-adapter .
 
+test:
+  - docker build -t telefonica/prometheus-kafka-adapter .
+  - docker run -d --name test telefonica/prometheus-kafka-adapter
+  - if [ $(docker inspect -f {{.State.Status}} test) = "running" ]; then echo "OK"; exit 0; else echo
+    "FAILED"; exit 1; fi
+
 git:
   depth: 1
   quiet: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ RUN go build -o /prometheus-kafka-adapter
 
 FROM alpine:3.11
 
-RUN apk add --no-cache librdkafka
+RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+    echo "@edgecommunity http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    apk add --no-cache 'librdkafka@edgecommunity>=1.3.0'
 
 COPY --from=build /src/prometheus-kafka-adapter/schemas/metric.avsc /schemas/metric.avsc
 COPY --from=build /prometheus-kafka-adapter /


### PR DESCRIPTION
Unfortunately we forget bumping `librdkafka` in the final Docker image in  #35 which prevents the image to be started:

```json
{"error":"confluent-kafka-go requires librdkafka v1.3.0 or later. Install the latest version of librdkafka from the Confluent repositories, see http://docs.confluent.io/current/installation.html: librdkafka version 1.2.2 (0x10202ff) detected","level":"fatal","msg":"couldn't create kafka producer","time":"2020-03-03T07:33:12Z"}
```
This PR bumps the version in the final image and also adds a `test` stage to Travis, checking if the container can be started with default configuration. 

/cc @palmerabollo 