### PR TITLE
fix: no SSL config + add HostAliases (for external Kafka) and NodePort for external Prometheus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM golang:1.13.8-alpine3.11 as build
 
-RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
-RUN echo "@edgecommunity http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-RUN apk add --no-cache alpine-sdk 'librdkafka@edgecommunity>=1.3.0' 'librdkafka-dev@edgecommunity>=1.3.0'
+# Get prebuild libkafka
+RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
+    echo "@edgecommunity http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    apk add --no-cache alpine-sdk 'librdkafka@edgecommunity>=1.3.0' 'librdkafka-dev@edgecommunity>=1.3.0'
 
 WORKDIR /src/prometheus-kafka-adapter
 ADD . /src/prometheus-kafka-adapter

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ To connect to Kafka over SSL define the following additonal environment variable
 - `KAFKA_SSL_CLIENT_KEY_PASS`: Kafka SSL client certificate key password (optional), defaults to `""`
 - `KAFKA_SSL_CA_CERT_FILE`: Kafka SSL broker CA certificate file, defaults to `""`
 
+When deployed in a K8s Cluster using Helm and using a Kafka external to the cluster, it might be necessary to define the kafka hostname resolution locally (this fills the /etc/hosts of the container).
+
+Use a custom values.yaml file with section 'hostAliases' (as mentioned in default values.yaml).
+
 ### prometheus
 
 Prometheus needs to have a `remote_write` url configured, pointing to the '/receive' endpoint of the host and port where the prometheus-kafka-adapter service is running. For example:
@@ -68,6 +72,10 @@ Prometheus needs to have a `remote_write` url configured, pointing to the '/rece
 remote_write:
   - url: "http://prometheus-kafka-adapter:8080/receive"
 ```
+
+When deployed in a K8s Cluster using Helm and using an external Prometheus, it might be necessary to expose prometheus-kafka-adapter input port as a node port.
+
+Use a custom values.yaml file to set service.type: NodePort and service.nodeport:<PortNumber> (see comments in default values.yaml)
 
 ## development
 

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 	kafkaSslClientKeyFile  = ""
 	kafkaSslClientKeyPass  = ""
 	kafkaSslCACertFile     = ""
-	kafkaSslValidation     = true
+	kafkaSslValidation     = false
 	serializer             Serializer
 )
 

--- a/helm/prometheus-kafka-adapter/templates/deployment.yaml
+++ b/helm/prometheus-kafka-adapter/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
 {{ toYaml . | trimSuffix "\n" | indent 8 }}
 {{- end }}
     spec:
+    {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/prometheus-kafka-adapter/templates/service.yaml
+++ b/helm/prometheus-kafka-adapter/templates/service.yaml
@@ -14,6 +14,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http
+      {{- if .Values.service.nodeport }}
+      nodePort: {{ .Values.service.nodeport }}
+      {{- end }}
       protocol: TCP
       name: http
   selector:

--- a/helm/prometheus-kafka-adapter/values.yaml
+++ b/helm/prometheus-kafka-adapter/values.yaml
@@ -25,6 +25,12 @@ KAFKA_SSL_CLIENT_CERT:
 KAFKA_SSL_CLIENT_KEY:
 KAFKA_SSL_CA_CERT:
 
+# When deployed in a K8s cluster and using an external Kafka it might be necessary to define the kafka host here (fill the /etc/hosts of the container)
+# hostAliases:
+#  - ip: ""
+#    hostnames:
+#    - ""
+
 environment:
   # defines kafka endpoint and port, defaults to kafka:9092.
   KAFKA_BROKER_LIST: ""
@@ -77,6 +83,9 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  # To define a NodePort, overload in a custom values file
+  #   type: NodePort
+  #   nodeport: <value>
   type: ClusterIP
   port: 80
   annotations: {}

--- a/main.go
+++ b/main.go
@@ -34,14 +34,15 @@ func main() {
 		"batch.num.messages":       kafkaBatchNumMessages,
 		"go.batch.producer":        true,                   // Enable batch producer (for increased performance).
 		"go.delivery.reports":      false,                  // per-message delivery reports to the Events() channel
-		"ssl.ca.location":          kafkaSslCACertFile,     // CA certificate file for verifying the broker's certificate.
-		"ssl.certificate.location": kafkaSslClientCertFile, // Client's certificate
-		"ssl.key.location":         kafkaSslClientKeyFile,  // Client's key
-		"ssl.key.password":         kafkaSslClientKeyPass,  // Key password, if any.
 	}
 
 	if kafkaSslClientCertFile != "" && kafkaSslClientKeyFile != "" && kafkaSslCACertFile != "" {
-		kafkaConfig["security.protocol"] = "ssl"
+		kafkaSslValidation =                            true
+		kafkaConfig["security.protocol"] =              "ssl"
+		kafkaConfig["ssl.ca.location"] =                kafkaSslCACertFile      // CA certificate file for verifying the broker's certificate.
+		kafkaConfig["ssl.certificate.location"] =       kafkaSslClientCertFile  // Client's certificate
+		kafkaConfig["ssl.key.location"] =               kafkaSslClientKeyFile   // Client's key
+		kafkaConfig["ssl.key.password"] =               kafkaSslClientKeyPass   // Key password, if any.
 	}
 
 	producer, err := kafka.NewProducer(&kafkaConfig)


### PR DESCRIPTION
3 items here:
- add ability to send metrics from an external Prometheus (nodeport in Helm chart)
- add setting of remote kafka host (hostname resolution should be possible, use hostAliases of K8s)
- Fix the NoSSL case when Kafka is not using ssl, data injection was not possible is ssl parameters given in the libkafka context (see main.go)