### PR TITLE
implement templated topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There is a docker image `telefonica/prometheus-kafka-adapter:1.6.0` [available o
 Prometheus-kafka-adapter listens for metrics coming from Prometheus and sends them to Kafka. This behaviour can be configured with the following environment variables:
 
 - `KAFKA_BROKER_LIST`: defines kafka endpoint and port, defaults to `kafka:9092`.
-- `KAFKA_TOPIC`: defines kafka topic to be used, defaults to `metrics`.
+- `KAFKA_TOPIC`: defines kafka topic to be used, defaults to `metrics`. Could use go template, labels are passed (as a map) to the template: e.g: `metrics.{{ index . "__name__" }}` to use per-metric topic. Two template functions are available: replace (`{{ index . "__name__" | replace "message" "msg" }}`) and substring (`{{ index . "__name__" | substring 0 5 }}`)
 - `KAFKA_COMPRESSION`: defines the compression type to be used, defaults to `none`.
 - `KAFKA_BATCH_NUM_MESSAGES`: defines the number of messages to batch write, defaults to `10000`.
 - `SERIALIZATION_FORMAT`: defines the serialization format, can be `json`, `avro-json`, defaults to `json`.

--- a/prometheus.go
+++ b/prometheus.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func processWriteRequest(req *prompb.WriteRequest) ([][]byte, error) {
+func processWriteRequest(req *prompb.WriteRequest) (map[string][][]byte, error) {
 	logrus.WithField("var", req).Debugln()
 	return Serialize(serializer, req)
 }


### PR DESCRIPTION
Hello :)

Thank you for such adapter!

We need to distribute the metrics into different topics (one per cluster component), so we implemented templated topic relying on golang `template/text` (fast - we implemented the same logic for nats-kafka adapter and benchmarked it : https://github.com/nats-io/nats-kafka/pull/11), and on metric labels.

For the sake of clarifying our use case:
Our cluster is made of a set of components (µservices, applications,...). Each component has an associated channel and each component produce logs, metrics, events and traces.
Let's say the component A got the channel `component.a`, its logs will be published in kafka topic `logs.component.a`, its metrics will be published in kafka topic `metrics.component.a` and so on. Then spark applications can subscribe to the data that matter to them. For instance, one spark application may care about the ingress controller metrics, it then gonna subscribes to `metrics.component.ingress`.
Eventually, one may wish to have a per-metric topic, or even a per component per metric topic (`metrics.{{ index . "componentname" }}.{{ index ."__name__" }}`).