### PR TITLE
Added: support sasl/scram authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ To connect to Kafka over SSL define the following additonal environment variable
 - `KAFKA_SSL_CLIENT_KEY_PASS`: Kafka SSL client certificate key password (optional), defaults to `""`
 - `KAFKA_SSL_CA_CERT_FILE`: Kafka SSL broker CA certificate file, defaults to `""`
 
+To connect to Kafka over SASL/SCRAM authentication define the following additonal environment variables:
+
+- `KAFKA_SECURITY_PROTOCOL`: Kafka client used protocol to communicate with brokers, you can set it explicitly or ignore it
+- `KAFKA_SASL_MECHANISM`: SASL mechanism to use for authentication, defaults to `""`
+- `KAFKA_SASL_USERNAME`: SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms, defaults to `""`
+- `KAFKA_SASL_PASSWORD`: SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism, defaults to `""`
+
 When deployed in a Kubernetes cluster using Helm and using a Kafka external to the cluster, it might be necessary to define the kafka hostname resolution locally (this fills the /etc/hosts of the container). Use a custom values.yaml file with section `hostAliases` (as mentioned in default values.yaml).
 
 ### prometheus

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To connect to Kafka over SSL define the following additonal environment variable
 
 To connect to Kafka over SASL/SCRAM authentication define the following additonal environment variables:
 
-- `KAFKA_SECURITY_PROTOCOL`: Kafka client used protocol to communicate with brokers, you can set it explicitly or ignore it
+- `KAFKA_SECURITY_PROTOCOL`: Kafka client used protocol to communicate with brokers, must be set if SASL is going to be used, either plain or with SSL
 - `KAFKA_SASL_MECHANISM`: SASL mechanism to use for authentication, defaults to `""`
 - `KAFKA_SASL_USERNAME`: SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms, defaults to `""`
 - `KAFKA_SASL_PASSWORD`: SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism, defaults to `""`

--- a/config.go
+++ b/config.go
@@ -36,6 +36,10 @@ var (
 	kafkaSslClientKeyPass  = ""
 	kafkaSslCACertFile     = ""
 	kafkaSslValidation     = false
+	kafkaSecurityProtocol  = ""
+	kafkaSaslMechanism     = ""
+	kafkaSaslUsername      = ""
+	kafkaSaslPassword      = ""
 	serializer             Serializer
 )
 
@@ -86,6 +90,22 @@ func init() {
 
 	if value := os.Getenv("KAFKA_SSL_CA_CERT_FILE"); value != "" {
 		kafkaSslCACertFile = value
+	}
+
+	if value := os.Getenv("KAFKA_SECURITY_PROTOCOL"); value != "" {
+		kafkaSecurityProtocol = value
+	}
+
+	if value := os.Getenv("KAFKA_SASL_MECHANISM"); value != "" {
+		kafkaSaslMechanism = value
+	}
+
+	if value := os.Getenv("KAFKA_SASL_USERNAME"); value != "" {
+		kafkaSaslUsername = value
+	}
+
+	if value := os.Getenv("KAFKA_SASL_PASSWORD"); value != "" {
+		kafkaSaslPassword = value
 	}
 
 	var err error

--- a/config.go
+++ b/config.go
@@ -35,7 +35,6 @@ var (
 	kafkaSslClientKeyFile  = ""
 	kafkaSslClientKeyPass  = ""
 	kafkaSslCACertFile     = ""
-	kafkaSslValidation     = false
 	kafkaSecurityProtocol  = ""
 	kafkaSaslMechanism     = ""
 	kafkaSaslUsername      = ""
@@ -93,7 +92,7 @@ func init() {
 	}
 
 	if value := os.Getenv("KAFKA_SECURITY_PROTOCOL"); value != "" {
-		kafkaSecurityProtocol = value
+		kafkaSecurityProtocol = strings.ToLower(value)
 	}
 
 	if value := os.Getenv("KAFKA_SASL_MECHANISM"); value != "" {

--- a/main.go
+++ b/main.go
@@ -45,6 +45,22 @@ func main() {
 		kafkaConfig["ssl.key.password"] = kafkaSslClientKeyPass          // Key password, if any.
 	}
 
+	if kafkaSaslMechanism != "" && kafkaSaslUsername != "" && kafkaSaslPassword != "" {
+		if kafkaSecurityProtocol != "" {
+			kafkaConfig["security.protocol"] = kafkaSecurityProtocol
+		} else {
+			if v, _ := kafkaConfig.Get("security.protocol", nil); v == nil {
+				kafkaConfig["security.protocol"] = "sasl_plaintext"
+			} else {
+				kafkaConfig["security.protocol"] = "sasl_ssl"
+			}
+		}
+
+		kafkaConfig["sasl.mechanism"] = kafkaSaslMechanism
+		kafkaConfig["sasl.username"] = kafkaSaslUsername
+		kafkaConfig["sasl.password"] = kafkaSaslPassword
+	}
+
 	producer, err := kafka.NewProducer(&kafkaConfig)
 
 	if err != nil {
@@ -66,5 +82,5 @@ func main() {
 		r.POST("/receive", receiveHandler(producer, serializer))
 	}
 
-	r.Run()
+	log.Fatal(r.Run())
 }


### PR DESCRIPTION
kafka client connect broker support SASL/SCRAM-* authentication, for example:

```
export KAFKA_BROKER_LIST="kafka1:9092,kafka2:9092,kafka3:9092"
export KAFKA_TOPIC="metrics"
export KAFKA_SECURITY_PROTOCOL="sasl_plaintext"
export KAFKA_SASL_MECHANISM="SCRAM-SHA-256"
export KAFKA_SASL_USERNAME="uptime"
export KAFKA_SASL_PASSWORD="testkey"

./prometheus-kafka-adapter
```