### PR TITLE
Describe better build pattern

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /src/prometheus-kafka-adapter
 ADD . /src/prometheus-kafka-adapter
 
 RUN go test
-RUN go build -o /prometheus-kafka-adapter
+RUN go build -tags static -o /prometheus-kafka-adapter
 
 FROM alpine:3.11
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ When deployed in a Kubernetes cluster using Helm and using an external Prometheu
 
 ## development
 
+Building requires librdkafka be available on the building host. It is typically available in distribution package archives, but can also be downloaded and built from here: https://github.com/edenhill/librdkafka.git
+
 ```
 go test
 go build -tags static

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ When deployed in a Kubernetes cluster using Helm and using an external Prometheu
 
 ```
 go test
-go build
+go build -tags static
 ```
 
 ## contributing


### PR DESCRIPTION
With confluent-kafka-go and librdkafka, we can still build a static binary that is re-distributable. It just requires adding the `-tags static` switch to the build command.