### PR TITLE
fix: update broken alpine dep in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM golang:1.14.4-alpine3.11 as build
+FROM golang:1.14.4-alpine3.12 as build
 
 # Get prebuilt libkafka.
-# XXX stop using the edgecommunity channel once librdkafka 1.3.0+ is officially published
-RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-    echo "@edgecommunity http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    apk add --no-cache alpine-sdk 'librdkafka@edgecommunity>=1.3.0' 'librdkafka-dev@edgecommunity>=1.3.0'
+RUN apk add --no-cache alpine-sdk 'librdkafka>=1.3.0' 'librdkafka-dev>=1.3.0'
 
 WORKDIR /src/prometheus-kafka-adapter
 ADD . /src/prometheus-kafka-adapter
@@ -12,11 +9,9 @@ ADD . /src/prometheus-kafka-adapter
 RUN go test
 RUN go build -o /prometheus-kafka-adapter
 
-FROM alpine:3.11
+FROM alpine:3.12
 
-RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
-    echo "@edgecommunity http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    apk add --no-cache 'librdkafka@edgecommunity>=1.3.0'
+RUN apk add --no-cache alpine-sdk 'librdkafka>=1.3.0' 'librdkafka-dev>=1.3.0'
 
 COPY --from=build /src/prometheus-kafka-adapter/schemas/metric.avsc /schemas/metric.avsc
 COPY --from=build /prometheus-kafka-adapter /

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go build -o /prometheus-kafka-adapter
 
 FROM alpine:3.12
 
-RUN apk add --no-cache alpine-sdk 'librdkafka>=1.3.0' 'librdkafka-dev>=1.3.0'
+RUN apk add --no-cache alpine-sdk 'librdkafka>=1.3.0'
 
 COPY --from=build /src/prometheus-kafka-adapter/schemas/metric.avsc /schemas/metric.avsc
 COPY --from=build /prometheus-kafka-adapter /


### PR DESCRIPTION
fix #60 

edge repositories evolve over time, becoming incompatible for librdkafka with alpine 3.11

this pr updates alpine to 3.12, minimum change required to fetch librdkafka >= 1.3

https://pkgs.alpinelinux.org/packages?name=librdkafka*&branch=v3.12&repo=community&arch=x86_64