### PR TITLE
fix: rm static from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ WORKDIR /src/prometheus-kafka-adapter
 ADD . /src/prometheus-kafka-adapter
 
 RUN go test
-RUN go build -tags static -o /prometheus-kafka-adapter
+RUN go build -o /prometheus-kafka-adapter
 
 FROM alpine:3.12
 
-RUN apk add --no-cache alpine-sdk 'librdkafka>=1.3.0'
+RUN apk add --no-cache 'librdkafka>=1.3.0'
 
 COPY --from=build /src/prometheus-kafka-adapter/schemas/metric.avsc /schemas/metric.avsc
 COPY --from=build /prometheus-kafka-adapter /


### PR DESCRIPTION
fix build error

```
Step 6/10 : RUN go build -tags static -o /prometheus-kafka-adapter
 ---> Running in 6867ff88d562
# github.com/confluentinc/confluent-kafka-go/kafka
gcc: error: /usr/lib/librdkafka-static.a: No such file or directory
The command '/bin/sh -c go build -tags static -o /prometheus-kafka-adapter' returned a non-zero code: 2
```