### PR TITLE
feat: update dockerfile base and deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Building requires librdkafka be available on the building host. It is typically 
 
 ```
 go test
-go build -tags static
+go build
 ```
 
 ## contributing

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/confluentinc/confluent-kafka-go v1.3.0
+	github.com/confluentinc/confluent-kafka-go v1.6.1
 	github.com/gin-gonic/contrib v0.0.0-20191209060500-d6e26eeaa607
 	github.com/gin-gonic/gin v1.6.3
 	github.com/gogo/protobuf v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/confluentinc/confluent-kafka-go v1.3.0 h1:1gJm/SgUqG01jRYJ1pSZ9GldAhXZ0xrFPKxINlVZ3z0=
-github.com/confluentinc/confluent-kafka-go v1.3.0/go.mod h1:MPUvNqmycSJrQZKGPS6LyLZLJH1hmLKkBmHQgQR7Ma0=
+github.com/confluentinc/confluent-kafka-go v1.6.1 h1:YxM/UtMQ2vgJX2gIgeJFUD0ANQYTEvfo4Cs4qKUlmGE=
+github.com/confluentinc/confluent-kafka-go v1.6.1/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
following @johnseekins https://github.com/Telefonica/prometheus-kafka-adapter/pull/59#issuecomment-795938264, this pr updates:
- go 1.16.1
  - switch to debian 10 buster (build)
- alpine 3.13 (final image)
- confluent-kafka-go 1.6.1

and enhances:
- go mod download (cache) prior to source code copy, results in faster development iterations
- `schemas/metric.avsc` copied directly from build context, not from build step
- static go build
- go build before go test, main syntax errors are unrelated to test phase
- revert #59 static comment from readme