### PR TITLE
Add match rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/linkedin/goavro v2.1.0+incompatible
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/prometheus/client_golang v0.8.0
-	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e
 	github.com/prometheus/procfs v0.1.3 // indirect
 	github.com/prometheus/prometheus v2.4.2+incompatible
@@ -23,6 +23,7 @@ require (
 	google.golang.org/grpc v1.15.0 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/linkedin/goavro.v1 v1.0.5 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 )
 
 go 1.13

--- a/helm/prometheus-kafka-adapter/templates/deployment.yaml
+++ b/helm/prometheus-kafka-adapter/templates/deployment.yaml
@@ -64,6 +64,10 @@ spec:
                 name: {{ include "prometheus-kafka-adapter.fullname" . }}
                 key: BASIC_AUTH_PASSWORD
           {{- end }}
+          {{- if .Values.environment.MATCH }}
+          - name: MATCH
+            value: {{ .Values.environment.MATCH | quote }}
+          {{- end }}
           - name: LOG_LEVEL
             value: {{ .Values.environment.LOG_LEVEL | quote }}
           - name: GIN_MODE

--- a/helm/prometheus-kafka-adapter/values.yaml
+++ b/helm/prometheus-kafka-adapter/values.yaml
@@ -63,6 +63,8 @@ environment:
   # Kafka SSL broker CA certificate file, defaults to "/ca_cert/ssl_ca_cert.pem" if
   # KAFKA_SSL_CA_CERT is provided, "" otherwise
   KAFKA_SSL_CA_CERT_FILE:
+  # defines the match rules, simple metric name match and label match
+  MATCH:
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
The data of Prometheus is of great value in both real time and offline time series data analysis. But at the same time, there is a lot of data in Prometheus that is not needed, which puts pressure on Kafka and wastes computation and storage. So we want the data to do some filtering before it goes into Kafka.  Based on the ideas provided by @palmerabollo https://github.com/Telefonica/prometheus-kafka-adapter/issues/54#issuecomment-670154428  , we made some slight improvements. Added simple matching rule feature.

Multiple matching rules with `;` separated. If we add the following matching rule:
```
foo;bar{x="1"};up{x="1",y="2"}
```
This means that we are sending the following three kinds of data to Kafka:

1.  Metric Name with `foo`
2. Metric Name with `bar` and the value of Label `x`  is equal to `1`
3. Metric Name with `up` and the value of Label `x`  is equal to `1` , the value of Label `y`  is equal to `2`

In high availability mode, we have 2 or more prometheus servers in a cluster.  By adding matching rules, it also helps to solve the data duplication problem. #54 