### PR TITLE
Building with librdkafka 1.6+ doesn't require librdkafka library any more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /src/prometheus-kafka-adapter
 ADD . /src/prometheus-kafka-adapter
 
 RUN go test
-RUN go build -o /prometheus-kafka-adapter
+RUN go build -tags static -o /prometheus-kafka-adapter
 
 FROM alpine:3.11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.16.3-buster as build
 
-RUN apt update
-
 WORKDIR /src/prometheus-kafka-adapter
 
 COPY go.mod .

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ When deployed in a Kubernetes cluster using Helm and using an external Prometheu
 
 ## development
 
+Building requires librdkafka be available on the building host. It is typically available in distribution package archives, but can also be downloaded and built from here: https://github.com/edenhill/librdkafka.git
+
 ```
 go test
 go build -tags static

--- a/README.md
+++ b/README.md
@@ -78,11 +78,9 @@ When deployed in a Kubernetes cluster using Helm and using an external Prometheu
 
 ## development
 
-Building requires librdkafka be available on the building host. It is typically available in distribution package archives, but can also be downloaded and built from here: https://github.com/edenhill/librdkafka.git
-
 ```
 go test
-go build -tags static
+go build
 ```
 
 ## contributing

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ When deployed in a Kubernetes cluster using Helm and using an external Prometheu
 
 ```
 go test
-go build
+go build -tags static
 ```
 
 ## contributing


### PR DESCRIPTION
As proof:

```
$ git log | head -n 20
commit 79930f5b3829279f282a9f5866a7e412cbcf549a
Merge: dc1cfdd d1cbd70
Author: John Seekins <jseekins@datto.com>
Date:   Mon May 3 10:07:32 2021 -0600

    remove build of librdkafka (comes with package now):

commit d1cbd70c213248b3597adbdd4d2ddbf6173b47bd
Author: Gallardot <tttick@163.com>
Date:   Sun Apr 11 01:54:21 2021 +0800

    add match rule (#64)

commit 732b9f69e14169c86daefdcc1cba41e8615be9fb
Author: Javier Provecho (Telefonica) <54402687+jpfe-tid@users.noreply.github.com>
Date:   Mon Mar 15 08:08:25 2021 +0100

    feat: update dockerfile base and deps (#63)

commit 1c0fdd9b1702e8726202f56af20df245ba7911f7
jseekins@quietthinkpad:~/github/prometheus-kafka-adapter$ docker run --rm -v $(pwd):/app:z -w /app golang:1.16.1-buster go build -o prometheus-kafka-adapter .
go: downloading github.com/gogo/protobuf v1.3.1
go: downloading github.com/gin-gonic/contrib v0.0.0-20191209060500-d6e26eeaa607
go: downloading github.com/golang/snappy v0.0.1
go: downloading github.com/gin-gonic/gin v1.6.3
go: downloading github.com/confluentinc/confluent-kafka-go v1.6.1
go: downloading github.com/linkedin/goavro v2.1.0+incompatible
go: downloading github.com/prometheus/client_golang v0.8.0
go: downloading github.com/prometheus/client_model v0.2.0
go: downloading github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e
go: downloading github.com/prometheus/prometheus v2.4.2+incompatible
go: downloading github.com/sirupsen/logrus v1.6.0
go: downloading gopkg.in/yaml.v2 v2.2.8
go: downloading github.com/golang/protobuf v1.3.3
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/prometheus/procfs v0.1.3
go: downloading github.com/gin-contrib/sse v0.1.0
go: downloading github.com/mattn/go-isatty v0.0.12
go: downloading gopkg.in/alecthomas/kingpin.v2 v2.2.6
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
go: downloading golang.org/x/sys v0.0.0-20200116001909-b77594299b42
go: downloading github.com/go-playground/validator/v10 v10.2.0
go: downloading github.com/ugorji/go v1.1.7
go: downloading github.com/grpc-ecosystem/grpc-gateway v1.5.0
go: downloading golang.org/x/net v0.0.0-20180826012351-8a410e7b638d
go: downloading google.golang.org/genproto v0.0.0-20180928223349-c7e5094acea1
go: downloading google.golang.org/grpc v1.15.0
go: downloading github.com/ugorji/go/codec v1.1.7
go: downloading github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
go: downloading github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
go: downloading github.com/go-playground/universal-translator v0.17.0
go: downloading github.com/leodido/go-urn v1.2.0
go: downloading golang.org/x/text v0.3.2
go: downloading github.com/go-playground/locales v0.13.0
jseekins@quietthinkpad:~/github/prometheus-kafka-adapter$ ./prometheus-kafka-adapter 
{"level":"warning","msg":"invalid serialization format, using json","serialization-format-value":"","time":"2021-05-03T10:08:55-06:00"}
INFO[0000] creating kafka producer                       source="main.go:29"
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:	export GIN_MODE=release
 - using code:	gin.SetMode(gin.ReleaseMode)

[GIN-debug] GET    /metrics                  --> github.com/gin-gonic/gin.WrapH.func1 (3 handlers)
[GIN-debug] POST   /receive                  --> main.receiveHandler.func1 (3 handlers)
[GIN-debug] Environment variable PORT is undefined. Using port :8080 by default
[GIN-debug] Listening and serving HTTP on :8080
%3|1620058136.932|FAIL|rdkafka#producer-1| [thrd:kafka:9092/bootstrap]: kafka:9092/bootstrap: Failed to resolve 'kafka:9092': Name or service not known (after 1497ms in state CONNECT)
^C
```

Essentially, we can simplify the build down to nearly one command. Which is kinda nice.