### PR TITLE
add healthcheck endpoint

### DIFF
--- a/helm/prometheus-kafka-adapter/templates/deployment.yaml
+++ b/helm/prometheus-kafka-adapter/templates/deployment.yaml
@@ -97,11 +97,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /metrics
+              path: /health
               port: http
           readinessProbe:
             httpGet:
-              path: /metrics
+              path: /health
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/prometheus-kafka-adapter/templates/deployment.yaml
+++ b/helm/prometheus-kafka-adapter/templates/deployment.yaml
@@ -97,11 +97,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: http
           readinessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func main() {
 	r.Use(ginrus.Ginrus(logrus.StandardLogger(), time.RFC3339, true), gin.Recovery())
 
 	r.GET("/metrics", gin.WrapH(prometheus.UninstrumentedHandler()))
+	r.GET("/health", func(c *gin.Context) { c.JSON(200, gin.H{"status": "UP"}) })
 	if basicauth {
 		authorized := r.Group("/", gin.BasicAuth(gin.Accounts{
 			basicauthUsername: basicauthPassword,

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 	r.Use(ginrus.Ginrus(logrus.StandardLogger(), time.RFC3339, true), gin.Recovery())
 
 	r.GET("/metrics", gin.WrapH(prometheus.UninstrumentedHandler()))
-	r.GET("/health", func(c *gin.Context) { c.JSON(200, gin.H{"status": "UP"}) })
+	r.GET("/healthz", func(c *gin.Context) { c.JSON(200, gin.H{"status": "UP"}) })
 	if basicauth {
 		authorized := r.Group("/", gin.BasicAuth(gin.Accounts{
 			basicauthUsername: basicauthPassword,


### PR DESCRIPTION
Simple endpoint for load balancers to check individual instances. Lighter-weight than using `/metrics`.