### PR TITLE
Fix SASL_SCRAM authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ To connect to Kafka over SASL/SCRAM authentication define the following additona
 - `KAFKA_SASL_MECHANISM`: SASL mechanism to use for authentication, defaults to `""`
 - `KAFKA_SASL_USERNAME`: SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms, defaults to `""`
 - `KAFKA_SASL_PASSWORD`: SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism, defaults to `""`
+- `KAFKA_SSL_CA_CERT_FILE`: Kafka SSL broker CA certificate file, defaults to `""`
 
 When deployed in a Kubernetes cluster using Helm and using a Kafka external to the cluster, it might be necessary to define the kafka hostname resolution locally (this fills the /etc/hosts of the container). Use a custom values.yaml file with section `hostAliases` (as mentioned in default values.yaml).
 

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func main() {
 		}
 
 		kafkaConfig["security.protocol"] = kafkaSecurityProtocol
+		kafkaConfig["ssl.ca.location"] = kafkaSslCACertFile // CA certificate file for verifying the broker's certificate.
 		kafkaConfig["sasl.mechanism"] = kafkaSaslMechanism
 		kafkaConfig["sasl.username"] = kafkaSaslUsername
 		kafkaConfig["sasl.password"] = kafkaSaslPassword


### PR DESCRIPTION
SASL_SCRAM authentication is not working, it's necessary to also add the KAFKA_SSL_CA_CERT_FILE line to the kafkaSaslMechanism if.
