### PR TITLE
Add ca.location support to SASL_SCRAM auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ To connect to Kafka over SASL/SCRAM authentication define the following addition
 - `KAFKA_SASL_MECHANISM`: SASL mechanism to use for authentication, defaults to `""`
 - `KAFKA_SASL_USERNAME`: SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms, defaults to `""`
 - `KAFKA_SASL_PASSWORD`: SASL password for use with the PLAIN and SASL-SCRAM-.. mechanism, defaults to `""`
+- `KAFKA_SSL_CA_CERT_FILE`: Kafka SSL broker CA certificate file, defaults to `""`
 
 When deployed in a Kubernetes cluster using Helm and using a Kafka external to the cluster, it might be necessary to define the kafka hostname resolution locally (this fills the /etc/hosts of the container). Use a custom values.yaml file with section `hostAliases` (as mentioned in default values.yaml).
 

--- a/main.go
+++ b/main.go
@@ -60,6 +60,10 @@ func main() {
 		kafkaConfig["sasl.mechanism"] = kafkaSaslMechanism
 		kafkaConfig["sasl.username"] = kafkaSaslUsername
 		kafkaConfig["sasl.password"] = kafkaSaslPassword
+
+		if kafkaSslCACertFile != "" {
+		    kafkaConfig["ssl.ca.location"] = kafkaSslCACertFile
+		}
 	}
 
 	producer, err := kafka.NewProducer(&kafkaConfig)


### PR DESCRIPTION
If a self-signed CA file is used, it must be passed in for SASL_SCRAM to work correctly