### PR TITLE
add params acks

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,12 +16,13 @@ package main
 
 import (
 	"fmt"
-	dto "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/expfmt"
-	"gopkg.in/yaml.v2"
 	"os"
 	"strings"
 	"text/template"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"gopkg.in/yaml.v2"
 
 	"github.com/sirupsen/logrus"
 )
@@ -45,6 +46,7 @@ var (
 	kafkaSaslUsername      = ""
 	kafkaSaslPassword      = ""
 	serializer             Serializer
+	kafkaAcks              = "all"
 )
 
 func init() {
@@ -110,6 +112,9 @@ func init() {
 
 	if value := os.Getenv("KAFKA_SASL_PASSWORD"); value != "" {
 		kafkaSaslPassword = value
+	}
+	if value := os.Getenv("KAFKA_ACKS"); value != "" {
+		kafkaAcks = value
 	}
 
 	if value := os.Getenv("MATCH"); value != "" {

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 		"batch.num.messages":  kafkaBatchNumMessages,
 		"go.batch.producer":   true,  // Enable batch producer (for increased performance).
 		"go.delivery.reports": false, // per-message delivery reports to the Events() channel
+		"acks":                kafkaAcks,
 	}
 
 	if kafkaSslClientCertFile != "" && kafkaSslClientKeyFile != "" && kafkaSslCACertFile != "" {
@@ -62,7 +63,7 @@ func main() {
 		kafkaConfig["sasl.password"] = kafkaSaslPassword
 
 		if kafkaSslCACertFile != "" {
-		    kafkaConfig["ssl.ca.location"] = kafkaSslCACertFile
+			kafkaConfig["ssl.ca.location"] = kafkaSslCACertFile
 		}
 	}
 


### PR DESCRIPTION
export KAFKA_ACKS=0
If set to zero then the producer will not wait for any acknowledgment from the server at all. The record will be immediately added to the socket buffer and considered sent. No guarantee can be made that the server has received the record in this case, and the retries configuration will not take effect (as the client won't generally know of any failures). The offset given back for each record will always be set to -1.
export KAFKA_ACKS=1
 This will mean the leader will write the record to its local log but will respond without awaiting full acknowledgement from all followers. In this case should the leader fail immediately after acknowledging the record but before the followers have replicated it then the record will be lost.
export KAFKA_ACKS=all
This means the leader will wait for the full set of in-sync replicas to acknowledge the record. This guarantees that the record will not be lost as long as at least one in-sync replica remains alive. This is the strongest available guarantee. This is equivalent to the acks=-1 setting.