### PR TITLE
Add .PHONY declaration to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ GO_VER := 1.22.3
 LIBC_GO_VER := $(GO_VER)-bullseye
 MUSL_GO_VER := $(GO_VER)-alpine
 
+.PHONY: all fmt test build build-libc build-musl build-docker-image vendor-update clean
+
 all: fmt test build
 
 fmt:


### PR DESCRIPTION
### **Add .PHONY to Makefile targets**  

**Changes:**  
- Explicitly declares `all`, `fmt`, `test`, `build`, and other non-file targets as `.PHONY` in the Makefile.  

**Why?**  
- Ensures these targets **always execute** (even if a file/directory with the same name exists, e.g., `./clean`).  
- Follows **GNU Make conventions** ([Phony Targets docs](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html)).  
- Improves reliability and avoids potential edge cases in builds.  

**Impact:**  
- No functional changes—just better Makefile hygiene.  
